### PR TITLE
Adapt template to receive split numbers

### DIFF
--- a/verifier_groth16.cairo
+++ b/verifier_groth16.cairo
@@ -1,7 +1,7 @@
 #This is a template for cairo based on verifier_groth16.sol.ejs on snarkjs/templates
 %lang starknet
-%builtins range_check 
 
+from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.math import assert_nn, unsigned_div_rem
 from starkware.cairo.common.alloc import alloc
@@ -204,7 +204,7 @@ end
 
 #a_len, b1_len, b2_len and c_len are all 6, input_len would be 3 * amount of inputs
 @external
-func verifyProof{range_check_ptr : felt}(a_len : felt, a : felt*, b1_len : felt, b1 : felt*, b2_len : felt, b2 : felt*,
+func verifyProof{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(a_len : felt, a : felt*, b1_len : felt, b1 : felt*, b2_len : felt, b2 : felt*,
                                          c_len : felt, c : felt*, input_len : felt, input : felt*) -> (r : felt):
     alloc_locals
     let A : G1Point = BuildG1Point(a[0], a[1], a[2], a[3], a[4], a[5])
@@ -215,6 +215,7 @@ func verifyProof{range_check_ptr : felt}(a_len : felt, a : felt*, b1_len : felt,
     getBigInt3array(input, big_input, 0, 0, input_len/3)
 
     let proof : Proof = Proof(A, B, C)
-    return verify(big_input, proof, input_len)
+    let result : felt = verify(big_input, proof, input_len)
+    return(result)
 
 end

--- a/verifier_groth16.cairo
+++ b/verifier_groth16.cairo
@@ -1,11 +1,12 @@
 #This is a template for cairo based on verifier_groth16.sol.ejs on snarkjs/templates
+%lang starknet
 %builtins range_check 
 
 from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.math import assert_nn, unsigned_div_rem
 from starkware.cairo.common.alloc import alloc
-from alt_bn128_g1 import G1Point, g1, ec_add, ec_mul
-from alt_bn128_g2 import G2Point, g2
+from alt_bn128_g1 import G1Point, ec_add, ec_mul
+from alt_bn128_g2 import G2Point
 from alt_bn128_pair import pairing
 from alt_bn128_field import FQ12, is_zero, FQ2, fq12_diff, fq12_eq_zero, fq12_mul, fq12_one
 from bigint import BigInt3
@@ -133,7 +134,7 @@ func verifyingKey{range_check_ptr : felt}() -> (vk : VerifyingKey):
     )
 
     let beta2 : G2Point = BuildG2Point(
-        <%=vk_beta_2[0][3]%>, <%=vk_beta_2[0][4]%>, <%=vk_beta_2[0][5]%>
+        <%=vk_beta_2[0][3]%>, <%=vk_beta_2[0][4]%>, <%=vk_beta_2[0][5]%>,
         <%=vk_beta_2[0][0]%>, <%=vk_beta_2[0][1]%>, <%=vk_beta_2[0][2]%>,
         <%=vk_beta_2[1][3]%>, <%=vk_beta_2[1][4]%>, <%=vk_beta_2[1][5]%>,
         <%=vk_beta_2[1][0]%>, <%=vk_beta_2[1][1]%>, <%=vk_beta_2[1][2]%>
@@ -201,7 +202,8 @@ func getBigInt3array{range_check_ptr : felt}(input : felt*, output : BigInt3*, i
     return()
 end
 
-#a_len, b1_len, b2_len and c_len are all 6, input_len would be 3* inputs
+#a_len, b1_len, b2_len and c_len are all 6, input_len would be 3 * amount of inputs
+@external
 func verifyProof{range_check_ptr : felt}(a_len : felt, a : felt*, b1_len : felt, b1 : felt*, b2_len : felt, b2 : felt*,
                                          c_len : felt, c : felt*, input_len : felt, input : felt*) -> (r : felt):
     alloc_locals

--- a/verifier_groth16.cairo
+++ b/verifier_groth16.cairo
@@ -157,39 +157,38 @@ func pairingProd4{range_check_ptr : felt}(a1 : G1Point, a2 : G2Point, b1 : G1Poi
 
 end
 
-#Data reception needs to be changed in order to accomodate split up numbers
 func verifyingKey{range_check_ptr : felt}() -> (vk : VerifyingKey):
     alloc_locals
 	let alfa1 : G1Point = BuildG1Point(
-        <%=vk_alpha_1[0]%>,
-        <%=vk_alpha_1[1]%>
+        <%=vk_alpha_1[0]%>, <%=vk_alpha_1[1]%> <%=vk_alpha_1[2]%>,
+        <%=vk_alpha_1[3]%>, <%=vk_alpha_1[4]%>, <%=vk_alpha_1[5]%>,
     )
 
     let beta2 : G2Point = BuildG2Point(
-        <%=vk_beta_2[0][1]%>,
-        <%=vk_beta_2[0][0]%>,
-        <%=vk_beta_2[1][1]%>,
-        <%=vk_beta_2[1][0]%>
+        <%=vk_beta_2[0][3]%>, <%=vk_beta_2[0][4]%>, <%=vk_beta_2[0][5]%>
+        <%=vk_beta_2[0][0]%>, <%=vk_beta_2[0][1]%>, <%=vk_beta_2[0][2]%>,
+        <%=vk_beta_2[1][3]%>, <%=vk_beta_2[1][4]%>, <%=vk_beta_2[1][5]%>,
+        <%=vk_beta_2[1][0]%>, <%=vk_beta_2[1][1]%>, <%=vk_beta_2[1][2]%>
     )
 
     let gamma2 : G2Point = BuildG2Point(
-        <%=vk_gamma_2[0][1]%>,
-        <%=vk_gamma_2[0][0]%>,
-        <%=vk_gamma_2[1][1]%>,
-        <%=vk_gamma_2[1][0]%>
+        <%=vk_gamma_2[0][3]%>, <%=vk_gamma_2[0][4]%>, <%=vk_gamma_2[0][5]%>,
+        <%=vk_gamma_2[0][0]%>, <%=vk_gamma_2[0][1]%>, <%=vk_gamma_2[0][2]%>,
+        <%=vk_gamma_2[1][3]%>, <%=vk_gamma_2[1][4]%>, <%=vk_gamma_2[1][5]%>,
+        <%=vk_gamma_2[1][0]%>, <%=vk_gamma_2[1][1]%>, <%=vk_gamma_2[1][2]%>
     )
     let delta2 : G2Point = BuildG2Point(
-        <%=vk_delta_2[0][1]%>,
-        <%=vk_delta_2[0][0]%>,
-        <%=vk_delta_2[1][1]%>,
-        <%=vk_delta_2[1][0]%>
+        <%=vk_delta_2[0][3]%>, <%=vk_delta_2[0][4]%>, <%=vk_delta_2[0][5]%>,
+        <%=vk_delta_2[0][0]%>, <%=vk_delta_2[0][1]%>, <%=vk_delta_2[0][2]%>,
+        <%=vk_delta_2[1][3]%>, <%=vk_delta_2[1][4]%>, <%=vk_delta_2[1][5]%>,
+        <%=vk_delta_2[1][0]%>, <%=vk_delta_2[1][1]%>, <%=vk_delta_2[1][2]%>
     )
         
     let (IC : G1Point*) = alloc()
     <% for (let i=0; i<IC.length; i++) { %>
     let point_<%=i%> : G1Point =  BuildG1Point( 
-        <%=IC[i][0]%>,
-        <%=IC[i][1]%>)
+        <%=IC[i][0]%>, <%=IC[i][1]%>, <%=IC[i][2]%>,
+        <%=IC[i][3]%>, <%=IC[i][4]%>, <%=IC[i][5]%>)
     assert IC[<%=i%>] =  point_<%=i%>                                   
     <% } %>
     let IC_length : felt = <%=IC.length%> 

--- a/verifier_groth16.cairo
+++ b/verifier_groth16.cairo
@@ -43,7 +43,7 @@ end
 func BuildG2Point{range_check_ptr : felt}(a1 : felt, a2 : felt, a3 : felt, b1 : felt, b2 : felt, b3 : felt, c1 : felt, c2 : felt, c3 : felt, d1 : felt, d2 : felt, d3 : felt) -> (r : G2Point):
     alloc_locals
     let A : BigInt3 = BigInt3(a1,a2,a3)
-    let B : BigInt3 = BigInt3(b1,b2,b2)
+    let B : BigInt3 = BigInt3(b1,b2,b3)
     let C : BigInt3 = BigInt3(c1,c2,c3)    
     let D : BigInt3 = BigInt3(d1,d2,d3)
 
@@ -58,9 +58,9 @@ end
 func negateBigInt3{range_check_ptr : felt}(n : BigInt3) -> (r : BigInt3):
     let (_, nd0) = unsigned_div_rem(n.d0, 60193888514187762220203335)
     let d0 = 60193888514187762220203335 -nd0
-    let (_, nd1) = unsigned_div_rem(n.d1, 60193888514187762220203335)
+    let (_, nd1) = unsigned_div_rem(n.d1, 104997207448309323063248289)
     let d1 = 104997207448309323063248289 -nd1
-    let (_, nd2) = unsigned_div_rem(n.d2, 60193888514187762220203335)
+    let (_, nd2) = unsigned_div_rem(n.d2, 3656382694611191768777987)
     let d2 = 3656382694611191768777987 -nd2
 
     return(BigInt3(d0,d1,d2))

--- a/verifier_groth16.cairo
+++ b/verifier_groth16.cairo
@@ -106,38 +106,6 @@ func pairings{range_check_ptr : felt}(p1 : G1Point*, p2: G2Point*, length : felt
     return(result)
  end
 
-#Pairing check for two pairs
-func pairingProd2{range_check_ptr : felt}(a1 : G1Point, a2 : G2Point, b1 : G1Point, b2 : G2Point) -> (r : felt):
-    let (p1 : G1Point*) = alloc()
-    let (p2 : G2Point*) = alloc()
-
-    assert p1[0] = a1
-    assert p1[1] = b1
-
-    assert p2[0] = a2
-    assert p2[1] = b2
-
-    return pairings(p1,p2,2)
-
-end
-
-#Pairing check for three pairs
-func pairingProd3{range_check_ptr : felt}(a1 : G1Point, a2 : G2Point,  b1 : G1Point, b2 : G2Point, c1 : G1Point, c2 : G2Point) -> (r : felt):
-    let (p1 : G1Point*) = alloc()
-    let (p2 : G2Point*) = alloc()
-
-    assert p1[0] = a1
-    assert p1[1] = b1
-    assert p1[2] = c1
-
-    assert p2[0] = a2
-    assert p2[1] = b2
-    assert p2[2] = c2
-
-    return pairings(p1,p2,3)
-
-end
-
 #Pairing check for four pairs
 func pairingProd4{range_check_ptr : felt}(a1 : G1Point, a2 : G2Point, b1 : G1Point, b2 : G2Point, c1 : G1Point, c2 : G2Point, d1 : G1Point, d2 : G2Point) -> (r : felt):
     let (p1 : G1Point*) = alloc()
@@ -160,7 +128,7 @@ end
 func verifyingKey{range_check_ptr : felt}() -> (vk : VerifyingKey):
     alloc_locals
 	let alfa1 : G1Point = BuildG1Point(
-        <%=vk_alpha_1[0]%>, <%=vk_alpha_1[1]%> <%=vk_alpha_1[2]%>,
+        <%=vk_alpha_1[0]%>, <%=vk_alpha_1[1]%>, <%=vk_alpha_1[2]%>,
         <%=vk_alpha_1[3]%>, <%=vk_alpha_1[4]%>, <%=vk_alpha_1[5]%>,
     )
 


### PR DESCRIPTION
Change data reception on verifyingKey function
Change how proof is created to accommodate the new format of the inputs
Remove unused pairing functions